### PR TITLE
fix rainlang dep url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@codemirror/view": "^6.9.3",
                 "@lezer/highlight": "^1.1.3",
                 "@lezer/lr": "^1.3.3",
-                "@rainprotocol/rainlang": "github:rainprotocol/rainlang?cc6382e69b725197f8e930fefa08a4d0ce736f1f"
+                "@rainprotocol/rainlang": "git+https://github.com/rainprotocol/rainlang#cc6382e69b725197f8e930fefa08a4d0ce736f1f"
             },
             "devDependencies": {
                 "@babel/core": "^7.18.6",
@@ -7304,7 +7304,7 @@
         },
         "@rainprotocol/rainlang": {
             "version": "git+ssh://git@github.com/rainprotocol/rainlang.git#cc6382e69b725197f8e930fefa08a4d0ce736f1f",
-            "from": "@rainprotocol/rainlang@github:rainprotocol/rainlang?cc6382e69b725197f8e930fefa08a4d0ce736f1f",
+            "from": "@rainprotocol/rainlang@git+https://github.com/rainprotocol/rainlang#cc6382e69b725197f8e930fefa08a4d0ce736f1f",
             "requires": {
                 "ajv": "^8.12.0",
                 "algebra.js": "rouzwelt/algebra.js",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
         "@codemirror/view": "^6.9.3",
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.3",
-        "@rainprotocol/rainlang": "github:rainprotocol/rainlang?cc6382e69b725197f8e930fefa08a4d0ce736f1f"
+        "@rainprotocol/rainlang": "git+https://github.com/rainprotocol/rainlang#cc6382e69b725197f8e930fefa08a4d0ce736f1f"
     }
 }


### PR DESCRIPTION
Fixed error when importing rainlang-codemirror as a git dependency

```
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote https://github.com/rainprotocol/rainlang?cc6382e69b725197f8e930fefa08a4d0ce736f1f.git HEAD
Directory: /home/marcus/rain-svelte-components
Output:
fatal: https://github.com/rainprotocol/rainlang?cc6382e69b725197f8e930fefa08a4d0ce736f1f.git/info/refs not valid: is this a git repository?
```